### PR TITLE
set-path deprecated from 16 november

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       run: nuget restore SpeckleGSA.sln
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Run msbuild command in Release
       run: msbuild /property:Configuration=Release


### PR DESCRIPTION
set-path was deprecated and the action microsoft/setup-msbuid used it

See microsoft/setup-msbuild#33 for problem

moving to 1.0.2 fixes this